### PR TITLE
Enable F-Keys for numbered hotkeys

### DIFF
--- a/commonFunctions.ahk
+++ b/commonFunctions.ahk
@@ -75,7 +75,7 @@ callFunction(possibleFunction)
 
 getDesktopNumberFromHotkey(keyCombo)
 {
-	number := RegExReplace(keyCombo, "[^\d]", "")
+	number := RegExReplace(keyCombo, "(F\d+|[^\d])", "")
 	return number == 0 ? 10 : number
 }
 


### PR DESCRIPTION
If you used F-Keys (e.g. F24) as numbered hotkeys, the script did fail to find the correct desktop number, because the numbers in the KeyCombo of F24 were included to the desktop number. 
Example:
When the hotkey was F24, and I triggered F24 & 1, the found DesktopNumber was 241, which led to the creation of many desktops.